### PR TITLE
[FEAT] add tmp/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 # Mac
 .DS_Store
+tmp/


### PR DESCRIPTION
# Description
Many times there will be certain files, folders, resources, that need to be accessed while developing. These resources will most likely be related to the project itself. To avoid scrambling files across your system and keeping them in one place, that is the repo, a `tmp/` directory will be created which will have all of your untracked resources.

## Type of Change
- [ ] Bug fix (Issue / Bug fixed | Non-breaking)
- [x] Feature (New feature | Non-breaking)
- [ ] Breaking Change
- [ ] Refactor
